### PR TITLE
Remove example plugins from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,6 @@
     "@folio/developer": "latest",
     "@folio/circulation": "latest",
     "@folio/eholdings": "latest",
-    "@folio/plugin-markdown-editor": "latest",
-    "@folio/plugin-markdown-better": "latest",
     "@folio/plugin-find-user": "latest",
     "@folio/stripes-core": "latest",
     "@folio/stripes-components": "latest"


### PR DESCRIPTION
The example plugins were just POC and they can break integration builds when pulling in old copies of dependencies that conflict with newer versions of themselves.