### PR TITLE
Try a little harder to find @folio dir when building module_descriptors

### DIFF
--- a/build-module-descriptors.js
+++ b/build-module-descriptors.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const childProcess = require('child_process');
 
 const argv0 = process.argv[1];
-const indir = 'node_modules/@folio';
+const indir = fs.existsSync('node_modules/@folio') ? 'node_modules/@folio' : '../node_modules/@folio';
 const outdir = 'ModuleDescriptors';
 let strict = false;
 if (process.argv[2] === '--strict') {


### PR DESCRIPTION
Adds a check to build-module-descriptors.js so it looks under the parent directory too and thus doesn't choke in a workspace environment.