### PR TITLE
Use react-bootstrap 0.32.1 specifically FOLIO-1425

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@folio/stripes-components": ">=0.0.0"
   },
   "resolutions": {
-    "**/uglify-es": "3.3.9"
+    "**/uglify-es": "3.3.9",
+    "react-bootstrap": "0.32.1"
   }
 }


### PR DESCRIPTION
*Purpose*
https://issues.folio.org/browse/FOLIO-1425

React-bootstrap 0.32.2 (released last night) introduces an incompatible dependency on babel-runtime ^7.0.0-beta.44

This is a temporary bandaid for the build until the dependency versions across different modules can be checked and limited / upgraded accordingly.